### PR TITLE
Text input with label component

### DIFF
--- a/components/TextInputWithLabel.tsx
+++ b/components/TextInputWithLabel.tsx
@@ -1,31 +1,34 @@
-import { View, Text, TextInput } from "react-native";
+import { View, Text, TextInput, StyleSheet } from "react-native";
 
 export default function TextInputWithLabel(props: {label: string}) {
-    const inputStyles = {
-        width: 272,
-        height: 44,
-        backgroundColor: "white",
-        borderWidth: 1,
-        borderRadius: 8,
-        borderColor: "black",
-        paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
-    };
-    const labelStyle = {
-        lineHeight: 16,
-        paddingBottom: 5,
-        fontSize: 16,
-        fontWeight: 500 //medium
-    }
-    const containerStyles = {
-        marginBottom: 20
-    }
+    const styles = StyleSheet.create({
+        input: {
+            width: 272,
+            height: 44,
+            backgroundColor: "white",
+            borderWidth: 1,
+            borderRadius: 8,
+            borderColor: "black",
+            paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
+        },
+        label: {
+            lineHeight: 16,
+            paddingBottom: 5,
+            fontSize: 16,
+            fontWeight: 500
+        },
+        container: {
+            marginBottom: 20
+        }
+    })
+
     return (
-        <View style={containerStyles}>
+        <View style={styles.container}>
             <Text 
                         nativeID={props.label}
-                        style={labelStyle}
+                        style={styles.label}
             >{props.label}</Text>
-            <TextInput  style={inputStyles}
+            <TextInput  style={styles.input}
                         accessibilityLabel={props.label}
                         accessibilityLabelledBy={props.label}
                         placeholder={props.label}

--- a/components/TextInputWithLabel.tsx
+++ b/components/TextInputWithLabel.tsx
@@ -1,0 +1,35 @@
+import { View, Text, TextInput } from "react-native";
+
+export default function TextInputWithLabel(props: {label: string}) {
+    const inputStyles = {
+        width: 272,
+        height: 44,
+        backgroundColor: "white",
+        borderWidth: 1,
+        borderRadius: 8,
+        borderColor: "black",
+        paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
+    };
+    const labelStyle = {
+        lineHeight: 16,
+        paddingBottom: 5,
+        fontSize: 16,
+        fontWeight: 500 //medium
+    }
+    const containerStyles = {
+        marginBottom: 20
+    }
+    return (
+        <View style={containerStyles}>
+            <Text 
+                        nativeID={props.label}
+                        style={labelStyle}
+            >{props.label}</Text>
+            <TextInput  style={inputStyles}
+                        accessibilityLabel={props.label}
+                        accessibilityLabelledBy={props.label}
+                        placeholder={props.label}
+            ></TextInput>
+        </View>
+    );
+}


### PR DESCRIPTION
Added the text input component, titled TextInputWithLabel to differentiate it from React Native's TextInput component which does not include labels or accessibility props.

The TextInputWithLabel provides a label, accessibility features like accessibilityLabelledBy, and StyleSheet object for CSS styling according to the Figma design.

If you're interested, there's documentation on the accessibility API at [https://reactnative.dev/docs/accessibility#accessibilitylabelledby-android](https://reactnative.dev/docs/accessibility#accessibilitylabelledby-android)

To use it, write ```<TextInputWithLabel label="x"/>```
For example:
![image](https://github.com/user-attachments/assets/fdbfafff-b9f5-45cb-99c9-a24739f7a0ee)