### PR TITLE
Quantity input

### DIFF
--- a/components/QuantityInput.tsx
+++ b/components/QuantityInput.tsx
@@ -1,0 +1,87 @@
+import { View, Text, TextInput, StyleSheet } from "react-native"
+import RoundButton from "./RoundButton";
+import { ChangeEvent, ChangeEventHandler, useState } from "react";
+
+function ensureInRangeInt(num: number) {
+    if (num < 0) return 0;
+    if (num > 99) return 99;
+    return Math.floor(num);
+}
+
+export default function QuantityInput(props: {initialValue: number}) {
+    const styles = StyleSheet.create({
+        input: {
+            width: 272,
+            height: 44,
+            backgroundColor: "white",
+            borderWidth: 1,
+            borderRadius: 8,
+            borderColor: "black",
+            paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
+        },
+        label: {
+            lineHeight: 16,
+            paddingBottom: 5,
+            fontSize: 16,
+            fontWeight: 500
+        },
+        container: {
+            marginBottom: 20
+        }
+    });
+
+    const newStyles = StyleSheet.create({
+        input: {
+            width: 50,
+            marginLeft: 5,
+            marginRight: 5,
+            textAlign: "center"
+        },
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between"
+        }
+    })
+
+    const [quantity, setQuantity] = useState(ensureInRangeInt(props.initialValue));
+    const [inputVal, setInputVal] = useState("" + quantity);
+
+    function updateQuantityBy(amount: number) {
+        const newNum = quantity + amount;
+        setQuantity(newNum);
+        setInputVal(newNum.toString());
+    }
+
+    return (
+        <View style={styles.container}>
+            <Text
+                style = {styles.label}
+                nativeID="quantity-label"
+            >Quantity</Text>
+            <View style={newStyles.row}>
+                <RoundButton label="—" disabled={quantity <= 0} onTouch={(() => updateQuantityBy(-1))}/>
+                <TextInput
+                    style={[styles.input, newStyles.input]}
+                    keyboardType="numeric"
+                    accessibilityLabel="Quantity"
+                    accessibilityLabelledBy="quantity-label"
+                    defaultValue = {inputVal}
+                    value = {inputVal}
+                    maxLength={2}
+                    onChangeText={num => {
+                        let cleanedNum = parseInt(num);
+                        if (isNaN(cleanedNum)) {
+                            setInputVal(num);
+                        } else {
+                            const value = ensureInRangeInt(cleanedNum); 
+                            setQuantity(value);
+                            setInputVal(value.toString());
+                        }
+                    }}
+                ></TextInput>
+                <RoundButton label="+" disabled={quantity >= 99} onTouch={() => updateQuantityBy(1)}/>
+            </View>
+        </View>
+    );
+}

--- a/components/RoundButton.tsx
+++ b/components/RoundButton.tsx
@@ -1,0 +1,41 @@
+import {useEffect, useState} from "react";
+import { Pressable, Text, StyleSheet } from "react-native";
+
+export default function RoundButton(props: {label: string, disabled: boolean, onTouch: CallableFunction}) {
+    const GRAY = "#D1D1D1";
+    const TEAL = "#B4E6E4";
+    let [color, setColor] = useState(props.disabled ? GRAY: TEAL);
+    useEffect(() => {
+        if (props.disabled) {
+            setColor(GRAY);
+        } else {
+            setColor(TEAL);
+        }
+    }, [props.disabled]);
+    const styles = StyleSheet.create({
+        button : {
+            width: 40,
+            height: 40,
+            backgroundColor: color,
+            borderRadius: 20
+        },
+        text: {
+            textAlign: "center",
+            lineHeight: 40,
+            fontWeight: 700
+        }    
+    })
+    return (
+        <Pressable
+            style={styles.button}
+            accessible
+            accessibilityLabel={props.label}
+            disabled={props.disabled}
+            onPressOut={() => {
+                props.onTouch();
+            }}
+        >
+            <Text style={styles.text}>{props.label}</Text>
+        </Pressable>
+    );
+}

--- a/components/TextInputWithLabel.tsx
+++ b/components/TextInputWithLabel.tsx
@@ -1,31 +1,34 @@
-import { View, Text, TextInput } from "react-native";
+import { View, Text, TextInput, StyleSheet } from "react-native";
 
 export default function TextInputWithLabel(props: {label: string}) {
-    const inputStyles = {
-        width: 272,
-        height: 44,
-        backgroundColor: "white",
-        borderWidth: 1,
-        borderRadius: 8,
-        borderColor: "black",
-        paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
-    };
-    const labelStyle = {
-        lineHeight: 16,
-        paddingBottom: 5,
-        fontSize: 16,
-        fontWeight: 500 //medium
-    }
-    const containerStyles = {
-        marginBottom: 20
-    }
+    const styles = StyleSheet.create({
+        input: {
+            width: 272,
+            height: 44,
+            backgroundColor: "white",
+            borderWidth: 1,
+            borderRadius: 8,
+            borderColor: "black",
+            paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
+        },
+        label: {
+            lineHeight: 16,
+            paddingBottom: 5,
+            fontSize: 16,
+            fontWeight: 500
+        },
+        container: {
+            marginBottom: 20
+        }
+    })
+
     return (
-        <View style={containerStyles}>
+        <View style={styles.container}>
             <Text 
                         nativeID={props.label}
-                        style={labelStyle}
+                        style={styles.label}
             >{props.label}</Text>
-            <TextInput  style={inputStyles}
+            <TextInput  style={styles.input}
                         accessibilityLabel={props.label}
                         accessibilityLabelledBy={props.label}
                         placeholder={props.label}

--- a/components/TextInputWithLabel.tsx
+++ b/components/TextInputWithLabel.tsx
@@ -1,0 +1,35 @@
+import { View, Text, TextInput } from "react-native";
+
+export default function TextInputWithLabel(props: {label: string}) {
+    const inputStyles = {
+        width: 272,
+        height: 44,
+        backgroundColor: "white",
+        borderWidth: 1,
+        borderRadius: 8,
+        borderColor: "black",
+        paddingLeft: 16, paddingRight: 16, paddingTop: 12, paddingBottom: 12
+    };
+    const labelStyle = {
+        lineHeight: 16,
+        paddingBottom: 5,
+        fontSize: 16,
+        fontWeight: 500 //medium
+    }
+    const containerStyles = {
+        marginBottom: 20
+    }
+    return (
+        <View style={containerStyles}>
+            <Text 
+                        nativeID={props.label}
+                        style={labelStyle}
+            >{props.label}</Text>
+            <TextInput  style={inputStyles}
+                        accessibilityLabel={props.label}
+                        accessibilityLabelledBy={props.label}
+                        placeholder={props.label}
+            ></TextInput>
+        </View>
+    );
+}


### PR DESCRIPTION
I implemented the RoundButton component, which takes a label, whether its currently disabled, and a function that defines what should happen when clicked (or tapped in this case)
I then created the QuantityInput component, which displays a label, - RoundButton, number input, and + RoundButton. When you click the buttons, they decrement/increment the number in the input. It also ensures the number can't go below 0 or above 99, and the buttons turn gray and are disabled when the input value is 0/99.
The styles match the Figma design, I mainly copied the styles from the TextInput file and extended them, but we could use a shared file specifically for styles that are relevant to multiple form inputs if we want to refactor style setup later.
The code from the [previous TextInput PR](https://github.com/roryhackney/autofridge/pull/1) is also in this PR so if we merge TextInput first and then this one it shouldn't cause any conflicts.

To test, replace index.tsx code with
```import QuantityInput from "@/components/QuantityInput";
import { Text, View } from "react-native";

export default function Index() {
  return (
    <View
      style={{
        flex: 1,
        justifyContent: "center",
        alignItems: "center",
      }}
    >
      <Text>Edit app/index.tsx to edit this screen.</Text>
      <QuantityInput initialValue={3}/>
    </View>
  );
}
```
Or just add ```<QuantityInput initialValue={3}/>``` to index.tsx.
Note the known bug that TodoListManager pushes other content to the bottom of the screen. If this occurs, delete the line invoking that component.
![image](https://github.com/user-attachments/assets/77ae6ad3-fec7-442a-9c63-908a8618b913)
